### PR TITLE
Enables command flag for search method

### DIFF
--- a/lib/lita/handlers/timdex_handler.rb
+++ b/lib/lita/handlers/timdex_handler.rb
@@ -5,8 +5,6 @@ module Lita
 
       route(/^ping/, :ping, help: { "ping" => "Checks TIMDEX!" })
 
-      route(/^echo\s+(.+)/, :echo)
-
       route(/^search\s+(.+)/, :search, command: true, help: { "search" => "Searches TIMDEX! for the provided string of text"})
 
       def ping(response)
@@ -18,10 +16,6 @@ module Lita
         pong = Timdex.new('FAKE_FOR_NOW', 'IT_WILL_WORK_ANYWAY').ping
 
         response.reply(render_template('ping', data: pong))
-      end
-
-      def echo(response)
-        response.reply(response.matches)
       end
 
       def search(response)

--- a/lib/lita/handlers/timdex_handler.rb
+++ b/lib/lita/handlers/timdex_handler.rb
@@ -7,7 +7,7 @@ module Lita
 
       route(/^echo\s+(.+)/, :echo)
 
-      route(/^search\s+(.+)/, :search, help: { "search" => "Searches TIMDEX! for the provided string of text"})
+      route(/^search\s+(.+)/, :search, command: true, help: { "search" => "Searches TIMDEX! for the provided string of text"})
 
       def ping(response)
         # Timdex no longer requires auth and will continue on just fine with

--- a/lib/lita/handlers/timdex_handler.rb
+++ b/lib/lita/handlers/timdex_handler.rb
@@ -3,7 +3,7 @@ module Lita
     class TimdexHandler < Handler
       # insert handler code here
 
-      route(/^ping/, :ping, help: { "ping" => "Checks TIMDEX!" })
+      route(/^ping/, :ping, command: true, help: { "ping" => "Checks TIMDEX!" })
 
       route(/^search\s+(.+)/, :search, command: true, help: { "search" => "Searches TIMDEX! for the provided string of text"})
 

--- a/spec/lita/handlers/timdex_spec.rb
+++ b/spec/lita/handlers/timdex_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe Lita::Handlers::TimdexHandler, lita_handler: true do
   it { is_expected.to route('lita ping').to(:ping) }
 
+  it { is_expected.not_to route('ping').to(:ping) }
+
   it 'can ping timdex' do
     send_message('lita ping')
     expect(replies.last).to eq('pong')
@@ -16,4 +18,6 @@ describe Lita::Handlers::TimdexHandler, lita_handler: true do
     expect(replies.last).to include('response(s) indicated')
     expect(replies.last).to include('ID:')
   end
+
+  it { is_expected.not_to route('search popcorn').to(:search) }
 end

--- a/spec/lita/handlers/timdex_spec.rb
+++ b/spec/lita/handlers/timdex_spec.rb
@@ -8,13 +8,6 @@ describe Lita::Handlers::TimdexHandler, lita_handler: true do
     expect(replies.last).to eq('pong')
   end
 
-  it { is_expected.to route('lita echo popcorn').to(:echo) }
-
-  it 'can echo stuff' do
-    send_message('lita echo can you hear me now?')
-    expect(replies.last).to eq('can you hear me now?')
-  end
-
   it { is_expected.to route('lita search popcorn').to(:search) }
 
   it 'can search stuff' do


### PR DESCRIPTION
This makes a few adjustments, which are generally laid out in MITLibraries/timbot#4

- Removes the echo command
- Adds the `command` flag to ping and search to prevent them from being invoked unintentionally
- Adds negative tests to ping and search to prevent inadvertent loss of the command flag in the future