### PR TITLE
Modify response template

### DIFF
--- a/spec/lita/handlers/timdex_spec.rb
+++ b/spec/lita/handlers/timdex_spec.rb
@@ -14,9 +14,8 @@ describe Lita::Handlers::TimdexHandler, lita_handler: true do
 
   it 'can search stuff' do
     send_message('lita search popcorn')
-    expect(replies.last).to include('Searching for "popcorn"')
-    expect(replies.last).to include('response(s) indicated')
-    expect(replies.last).to include('ID:')
+    expect(replies.last).to include('total result(s) for "popcorn"')
+    expect(replies.last).to include('https://library.mit.edu/item/')
   end
 
   it { is_expected.not_to route('search popcorn').to(:search) }

--- a/templates/search.erb
+++ b/templates/search.erb
@@ -1,12 +1,15 @@
-Searching for "<%= @data['needle'] %>"
+<%= @data['response']['hits'] %> total result(s) for "<%= @data['needle'] %>".
+<% current_set = [@data['response']['records'].count, 5].min %>
 
-<%= @data['response']['hits'] %> response(s) indicated
-<%= @data['response']['records'].length %> results returned. The first five are:
+<% if @data['response']['records'].count > 0 %>
+
+The first <%= current_set %> <% if current_set == 1 %>is<%else%>are<%end%>:
+<% end %>
 
 <% @data['response']['records'].first(5).each do |items| %>
+
 <%= items.title %>
 
-  ID: <%= items.id %>
   <%= items.source_link %>
 
 <% end %>


### PR DESCRIPTION
This removes the record ID as a distinct output and does some minor tweaks to text including basic pluralization around the current set returned numbers (Rails has this stuff built in but this is just Ruby so... argh!)

New results look like:

```
Lita > lita search popcorn
119 total result(s) for "popcorn".


The first 5 are:


Popcorn Venus /
  https://library.mit.edu/item/000346597


Popcorn Industry Profile: Belgium
  https://library.mit.edu/item/002623996


Popcorn Industry Profile: Denmark
  https://library.mit.edu/item/002176518


Popcorn Industry Profile: Australia
  https://library.mit.edu/item/002623995


Popcorn Industry Profile: Greece
  https://library.mit.edu/item/002624001
```

and for small result sets:
```
Lita > lita search badesi
1 total result(s) for "badesi".


The first 1 is:


Saiyan badesi ghar aaja re thumri /
  https://library.mit.edu/item/000942672
```